### PR TITLE
handle OSError errno 97 when ipv6 is disabled

### DIFF
--- a/sshutil/server.py
+++ b/sshutil/server.py
@@ -360,7 +360,12 @@ class SSHServer(object):
         # Bind first to IPv6, if the OS supports binding per AF then the IPv4
         # will succeed, otherwise the IPv6 will support both AF.
         for pname, host, proto in [("IPv6", '::', socket.AF_INET6), ("IPv4", '', socket.AF_INET)]:
-            protosocket = socket.socket(proto, socket.SOCK_STREAM)
+            try:
+                protosocket = socket.socket(proto, socket.SOCK_STREAM)
+            except OSError as e:
+                if e.errno == errno.EAFNOSUPPORT:
+                    continue
+                raise
             protosocket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             if self.debug:
                 logger.debug("Server binding to proto %s port %s", str(pname), str(port))


### PR DESCRIPTION
Hi,
I was using your netconf server library and I came across this error:
```
Traceback (most recent call last):
  File "server_exmaple.py", line 4, in <module>
    ssh_server = server.SSHServer(server_ctl, host_key="tests/host_key")
  File "/root/pysshutil/sshutil/server.py", line 363, in __init__
    protosocket = socket.socket(proto, socket.SOCK_STREAM)
  File "/usr/lib64/python3.6/socket.py", line 144, in __init__
    _socket.socket.__init__(self, family, type, proto, fileno)
OSError: [Errno 97] Address family not supported by protocol
Deleting SSHServer(port=0)
```
This happens when ipv6 is disabled in the OS. (This pull request is related also to [pull 7](https://github.com/choppsv1/pysshutil/pull/7)).
I managed to reproduce the error and this solution works fine for me. Please let me know what you think.
Thank you for your work.