### PR TITLE
Introduce timeout to connection

### DIFF
--- a/sshutil/conn.py
+++ b/sshutil/conn.py
@@ -55,7 +55,8 @@ class SSHConnection(object):
                  password=None,
                  debug=False,
                  cache=None,
-                 proxycmd=None):
+                 proxycmd=None,
+                 timeout=None):
         if cache is None:
             cache = g_cache
 
@@ -72,7 +73,7 @@ class SSHConnection(object):
 
         self.username = username
 
-        self.ssh = cache.get_ssh_socket(host, port, username, password, debug, proxycmd)
+        self.ssh = cache.get_ssh_socket(host, port, username, password, debug, proxycmd, timeout)
 
         # Open a session.
         try:
@@ -139,7 +140,8 @@ class SSHClientSession(SSHSession):
                  password=None,
                  debug=False,
                  cache=None,
-                 proxycmd=None):
+                 proxycmd=None,
+                 timeout=None):
         """Opens a client session to a host using a given subsystem.
 
         :param host: The host to execute the command on.
@@ -153,9 +155,10 @@ class SSHClientSession(SSHSession):
         :param cache: A connection cache to use.
         :type cache: SSHConnectionCache
         :param proxycmd: Proxy command to use when making the ssh connection.
+        :param timeout: Timeout to use for the SSH connection.
         """
         super(SSHClientSession, self).__init__(host, port, username, password, debug, cache,
-                                               proxycmd)
+                                               proxycmd, timeout)
         try:
             self.chan.invoke_subsystem(subsystem)
         except:
@@ -178,7 +181,8 @@ class SSHCommandSession(SSHSession):
                  password=None,
                  debug=False,
                  cache=None,
-                 proxycmd=None):
+                 proxycmd=None,
+                 timeout=None):
         """Open a client session to a host using a command i.e., like a remote pipe
 
         :param host: The host to execute the command on.
@@ -192,9 +196,10 @@ class SSHCommandSession(SSHSession):
         :param cache: A connection cache to use.
         :type cache: SSHConnectionCache
         :param proxycmd: Proxy command to use when making the ssh connection.
+        :param timeout: Timeout to use for the SSH connection.
         """
         super(SSHCommandSession, self).__init__(host, port, username, password, debug, cache,
-                                                proxycmd)
+                                                proxycmd, timeout)
         try:
             self.chan.exec_command(command)
         except:

--- a/tests/test_conn.py
+++ b/tests/test_conn.py
@@ -37,8 +37,9 @@ def setup_module(module):
      SSHNoConnectionCache("SSH Session no cache"), None])
 @pytest.mark.parametrize("proxycmd", [None, proxy])
 @pytest.mark.parametrize("debug", [False, True])
-def test_command_session(cache, proxycmd, debug):
-    session = SSHCommandSession("localhost", 22, "cat", debug=debug, cache=cache, proxycmd=proxycmd)
+@pytest.mark.parametrize("timeout", [None, 1])
+def test_command_session(cache, proxycmd, debug, timeout):
+    session = SSHCommandSession("localhost", 22, "cat", debug=debug, cache=cache, proxycmd=proxycmd, timeout=timeout)
     s = "foobar\n"
     session.sendall(s)
     s2 = session.recv(len(s)).decode('utf-8')


### PR DESCRIPTION
This PR introduces a timeout to the socket and, thus, to the connection. This is an addition that I personally require in the netconf module, and thus needs to be implemented here.

NB: I updated the tests, but I wasn’t able to make them run correctly on my machine. I’m hoping Travis is better than me in this regard.

Cheers

EDIT: If and when this gets accepted I’d also be open to patching the netconf module.